### PR TITLE
[tinygo] cmds/core/df: use os.Stat instead of unix.Stat() to retrieve…

### DIFF
--- a/cmds/core/df/dev.go
+++ b/cmds/core/df/dev.go
@@ -2,19 +2,29 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && !(mips || mips64 || mips64le || mipsle || plan9 || windows)
+//go:build !(mips || mips64 || mips64le || mipsle || plan9 || windows)
 
 package main
 
 import (
-	"golang.org/x/sys/unix"
+	"fmt"
+	"os"
+	"syscall"
 )
 
 func deviceNumber(path string) (uint64, error) {
-	st := &unix.Stat_t{}
-	err := unix.Stat(path, st)
+
+	// stat()
+	fi, err := os.Stat(path)
 	if err != nil {
 		return 0, err
 	}
+
+	// retrieve device number
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("stat %v: error retrieving devno", path)
+	}
+
 	return st.Dev, nil
 }

--- a/cmds/core/df/df.go
+++ b/cmds/core/df/df.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && !plan9 && !windows
+//go:build !plan9 && !windows
 
 // df reports details of mounted filesystems.
 //

--- a/cmds/core/df/df_test.go
+++ b/cmds/core/df/df_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && !plan9 && !windows
+//go:build !plan9 && !windows
 
 package main
 

--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	errUsage     = errors.New("usage")
-	errMountPath = errors.New("can't read mount path")
+	errMountPath = errors.New("can not read mount path")
 )
 
 type mountOptions []string

--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -17,8 +17,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -26,6 +28,11 @@ import (
 	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/u-root/pkg/mount/loop"
 	"golang.org/x/sys/unix"
+)
+
+var (
+	errUsage     = errors.New("usage")
+	errMountPath = errors.New("can't read mount path")
 )
 
 type mountOptions []string
@@ -41,14 +48,30 @@ func (o *mountOptions) Set(value string) error {
 	return nil
 }
 
-var (
-	ro      = flag.Bool("r", false, "Read only mount")
-	fsType  = flag.String("t", "", "File system type")
-	options mountOptions
-)
+type cmd struct {
+	stdout          io.Writer
+	stderr          io.Writer
+	fileSystemsPath string
+	fsType          string
+	mountsPath      []string
+	options         mountOptions
+	ro              bool
+}
 
-func init() {
-	flag.Var(&options, "o", "Comma separated list of mount options")
+func command(stdout, stderr io.Writer, ro bool, fsType string, opts mountOptions) *cmd {
+	return &cmd{
+		stdout: stdout,
+		stderr: stderr,
+		mountsPath: []string{
+			"/proc/self/mounts",
+			"/proc/mounts",
+			"/etc/mtab",
+		},
+		fileSystemsPath: "/proc/filesystems",
+		ro:              ro,
+		options:         opts,
+		fsType:          fsType,
+	}
 }
 
 func loopSetup(filename string) (loopDevice string, err error) {
@@ -63,10 +86,10 @@ func loopSetup(filename string) (loopDevice string, err error) {
 }
 
 // extended from boot.go
-func getSupportedFilesystem(originFS string) ([]string, bool, error) {
+func (c *cmd) getSupportedFilesystem(originFS string) ([]string, bool, error) {
 	var known bool
 	var err error
-	fs, err := os.ReadFile("/proc/filesystems")
+	fs, err := os.ReadFile(c.fileSystemsPath)
 	if err != nil {
 		return nil, known, err
 	}
@@ -85,45 +108,43 @@ func getSupportedFilesystem(originFS string) ([]string, bool, error) {
 	return returnValue, known, err
 }
 
-func informIfUnknownFS(originFS string) {
-	knownFS, known, err := getSupportedFilesystem(originFS)
+func (c *cmd) informIfUnknownFS(originFS string) {
+	knownFS, known, err := c.getSupportedFilesystem(originFS)
 	if err != nil {
 		// just don't make things even worse...
 		return
 	}
 	if !known {
-		log.Printf("Hint: unknown filesystem %s. Known are: %v", originFS, knownFS)
+		fmt.Fprintf(c.stderr, "Hint: unknown filesystem %s. Known are: %v", originFS, knownFS)
 	}
 }
 
-func main() {
-	if len(os.Args) == 1 {
-		n := []string{"/proc/self/mounts", "/proc/mounts", "/etc/mtab"}
-		for _, p := range n {
+func (c *cmd) run(args ...string) error {
+	if len(args) == 0 {
+		for _, p := range c.mountsPath {
 			if b, err := os.ReadFile(p); err == nil {
-				fmt.Print(string(b))
-				os.Exit(0)
+				c.stdout.Write(b)
+				return nil
 			}
 		}
-		log.Fatalf("Could not read %s to get namespace", n)
+		return fmt.Errorf("%w: %v to get namespace", errMountPath, c.mountsPath)
 	}
-	flag.Parse()
-	if len(flag.Args()) < 2 {
-		flag.Usage()
-		os.Exit(1)
+
+	if len(args) < 2 {
+		return errUsage
 	}
-	a := flag.Args()
-	dev := a[0]
-	path := a[1]
+
+	dev := args[0]
+	path := args[1]
 	var flags uintptr
 	var data []string
 	var err error
-	for _, option := range options {
+	for _, option := range c.options {
 		switch option {
 		case "loop":
 			dev, err = loopSetup(dev)
 			if err != nil {
-				log.Fatal("Error setting loop device:", err)
+				return fmt.Errorf("error setting loop device: %w", err)
 			}
 		default:
 			if f, ok := opts[option]; ok {
@@ -133,18 +154,37 @@ func main() {
 			}
 		}
 	}
-	if *ro {
+
+	if c.ro {
 		flags |= unix.MS_RDONLY
 	}
-	if *fsType == "" {
+	if c.fsType == "" {
 		if _, err := mount.TryMount(dev, path, strings.Join(data, ","), flags); err != nil {
-			log.Fatalf("%v", err)
+			return err
 		}
 	} else {
-		if _, err := mount.Mount(dev, path, *fsType, strings.Join(data, ","), flags); err != nil {
-			log.Printf("%v", err)
-			informIfUnknownFS(*fsType)
-			os.Exit(1)
+		if _, err := mount.Mount(dev, path, c.fsType, strings.Join(data, ","), flags); err != nil {
+			c.informIfUnknownFS(c.fsType)
+			return err
 		}
+	}
+
+	return nil
+}
+
+func main() {
+	ro := flag.Bool("r", false, "Read only mount")
+	fsType := flag.String("t", "", "File system type")
+	var options mountOptions
+	flag.Var(&options, "o", "Comma separated list of mount options")
+	flag.Parse()
+	cmd := command(os.Stdout, os.Stderr, *ro, *fsType, options)
+
+	err := cmd.run(flag.Args()...)
+	if errors.Is(err, errUsage) {
+		flag.Usage()
+		os.Exit(1)
+	} else if err != nil {
+		log.Fatal(err)
 	}
 }

--- a/cmds/core/mount/mount_test.go
+++ b/cmds/core/mount/mount_test.go
@@ -1,0 +1,141 @@
+// Copyright 2012-2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !tinygo && !plan9
+// +build !tinygo,!plan9
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"slices"
+	"sort"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	dir := t.TempDir()
+	procMounts, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	procMountContent := `sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+`
+	_, err = procMounts.WriteString(procMountContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		expectedErr    error
+		name           string
+		fsType         string
+		fileSystemPath string
+		expectedStdout string
+		opts           mountOptions
+		args           []string
+		mountPath      []string
+		ro             bool
+	}{
+		{
+			name:        "wrong usage",
+			args:        []string{"arg1"},
+			expectedErr: errUsage,
+		},
+		{
+			name:        "no mount path error",
+			expectedErr: errMountPath,
+		},
+		{
+			name:           "no args",
+			mountPath:      []string{procMounts.Name()},
+			expectedStdout: procMountContent,
+		},
+		{
+			name:        "mount not exist",
+			args:        []string{"/errNotExitPath", "/mount/somewhere"},
+			ro:          true,
+			expectedErr: os.ErrNotExist,
+		},
+	}
+
+	for _, test := range tests {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		cmd := command(stdout, stderr, test.ro, test.fsType, test.opts)
+		cmd.mountsPath = test.mountPath
+		cmd.fileSystemsPath = test.fileSystemPath
+
+		err := cmd.run(test.args...)
+		if !errors.Is(err, test.expectedErr) {
+			t.Fatalf("expected %v go %v", test.expectedErr, err)
+		}
+
+		if test.expectedStdout != stdout.String() {
+			t.Errorf("expected %v got %v", test.expectedStdout, stdout.String())
+		}
+	}
+}
+
+func TestGetSupportedFilesystem(t *testing.T) {
+	dir := t.TempDir()
+	pfs, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	procFSContent := `nodev	sysfs
+nodev	tmpfs
+nodev	bdev
+nodev	proc
+nodev	cgroup`
+
+	_, err = pfs.WriteString(procFSContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		originFS      string
+		fsPath        string
+		expectedErr   error
+		expectedList  []string
+		expectedKnown bool
+	}{
+		{
+			originFS:      "tmpfs",
+			fsPath:        pfs.Name(),
+			expectedKnown: true,
+			expectedList:  []string{"sysfs", "tmpfs", "bdev", "proc", "cgroup"},
+		},
+		{
+			originFS:      "tmpfs",
+			fsPath:        "filenotfound",
+			expectedKnown: false,
+			expectedErr:   os.ErrNotExist,
+		},
+	}
+
+	for _, test := range tests {
+		c := &cmd{fileSystemsPath: test.fsPath}
+		xs, known, err := c.getSupportedFilesystem(test.originFS)
+		if !errors.Is(err, test.expectedErr) {
+			t.Fatalf("expected error %v got %v", test.expectedErr, err)
+		}
+		if known != test.expectedKnown {
+			t.Errorf("expected known %t got %t", test.expectedKnown, known)
+		}
+
+		sort.Strings(xs)
+		sort.Strings(test.expectedList)
+		if !slices.Equal(xs, test.expectedList) {
+			t.Errorf("expected %v, got %v", test.expectedList, xs)
+		}
+	}
+}

--- a/tools/tinygobb/README.md
+++ b/tools/tinygobb/README.md
@@ -13,9 +13,9 @@ The neccessary additions to tinygo will be tracked in the according issue that t
 
 ## command list
 ### core
-41 tinygo build errors found.
+40 tinygo build errors found.
+
  - [ ] `bind`
- - [ ] `df`
  - [ ] `dhclient`
  - [ ] `dmesg`
  - [ ] `fusermount`
@@ -55,7 +55,7 @@ The neccessary additions to tinygo will be tracked in the according issue that t
  - [ ] `which`
  - [ ] `nohup`
 
-64 cmds build successful
+65 cmds build successful
 - [x] `backoff`
 - [x] `base64`
 - [x] `basename`
@@ -69,6 +69,7 @@ The neccessary additions to tinygo will be tracked in the according issue that t
 - [x] `cpio`
 - [x] `date`
 - [x] `dd`
+- [x] `df`
 - [x] `dirname`
 - [x] `echo`
 - [x] `false`
@@ -182,4 +183,3 @@ The neccessary additions to tinygo will be tracked in the according issue that t
 - [x] `watch`
 - [x] `zbi`
 - [x] `zimage`
-


### PR DESCRIPTION
… device number